### PR TITLE
Fix scroll position detection for lazy loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -7820,7 +7820,11 @@
       const unmonitoring = new WeakMap()
 
       elements.forEach(el => {
-        const scrollY = window.scrollY || window.scrollTop || 0
+        const scrollY =
+          window.scrollY ||
+          document.documentElement.scrollTop ||
+          document.body.scrollTop ||
+          0
         const height = window.innerHeight || window.clientHeight || 0
 
         const rect = el.getBoundingClientRect()


### PR DESCRIPTION
## Summary
- ensure lazy loading falls back to document scrollTop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3491437c8332af580a52e0643e49